### PR TITLE
chore: Google Fontsのdisplayオプションをoptionalからswapにする

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -5,7 +5,7 @@ export default function _Document() {
     <Html>
       <Head>
         <link
-          href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=optional"
+          href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap"
           rel="stylesheet"
         />
       </Head>


### PR DESCRIPTION
`display=swap`とは何か: https://t32k.me/mol/log/font-display-swap/